### PR TITLE
NUM-234: Skip tests when creating the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             fi
             echo "Publishing Docker image with following tag: ${TAG}"
             echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
-            ./mvnw spring-boot:build-image -Dspring-boot.build-image.imageName=$DOCKER_USER/num-portal:$TAG -Djdk.tls.client.protocols=TLSv1.2
+            ./mvnw spring-boot:build-image -Dspring-boot.build-image.imageName=$DOCKER_USER/num-portal:$TAG -DskipTests -Djdk.tls.client.protocols=TLSv1.2
             docker push $DOCKER_USER/num-portal:$TAG
 
 commands:


### PR DESCRIPTION
The maven command executes the tests unless those are explicitly disabled, since we have different step for tests, I thought it makes sense to disable those for image build