### PR TITLE
NUM-103: fixed cohortDto to cohort conversion

### DIFF
--- a/src/main/java/de/vitagroup/num/converter/CohortConverter.java
+++ b/src/main/java/de/vitagroup/num/converter/CohortConverter.java
@@ -19,83 +19,90 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class CohortConverter {
 
-    private final ModelMapper modelMapper;
-    private final PhenotypeService phenotypeService;
-    private final StudyService studyService;
+  private final ModelMapper modelMapper;
+  private final PhenotypeService phenotypeService;
+  private final StudyService studyService;
 
-    @PostConstruct
-    public void setUp() {
+  @PostConstruct
+  public void setUp() {
 
-        PropertyMap<CohortGroup, CohortGroupDto> cohortGroupDtoMap = new PropertyMap<>() {
-            protected void configure() {
-                map().setPhenotypeId(source.getPhenotype().getId());
-            }
+    PropertyMap<CohortGroup, CohortGroupDto> cohortGroupDtoMap =
+        new PropertyMap<>() {
+          protected void configure() {
+            map().setPhenotypeId(source.getPhenotype().getId());
+          }
         };
 
-        PropertyMap<Cohort, CohortDto> cohortDtoMap = new PropertyMap<>() {
-            protected void configure() {
-                map().setStudyId(source.getStudy().getId());
-            }
+    PropertyMap<Cohort, CohortDto> cohortDtoMap =
+        new PropertyMap<>() {
+          protected void configure() {
+            map().setStudyId(source.getStudy().getId());
+          }
         };
 
-        modelMapper.addMappings(cohortDtoMap);
-        modelMapper.addMappings(cohortGroupDtoMap);
+    modelMapper.addMappings(cohortDtoMap);
+    modelMapper.addMappings(cohortGroupDtoMap);
+  }
+
+  public CohortDto convertToDto(Cohort cohort) {
+    CohortDto cohortDto = modelMapper.map(cohort, CohortDto.class);
+    CohortGroupDto cohortGroupDto = convertToCohortGroupDto(cohort.getCohortGroup());
+    cohortDto.setCohortGroupDto(cohortGroupDto);
+    return cohortDto;
+  }
+
+  public Cohort convertToEntity(CohortDto dto) {
+    Cohort cohort = modelMapper.map(dto, Cohort.class);
+    cohort.setId(null);
+    Optional<Study> study = studyService.getStudyById(dto.getStudyId());
+
+    if (study.isPresent()) {
+      cohort.setStudy(study.get());
+      study.get().setCohort(cohort);
+    } else {
+      throw new BadRequestException("Invalid study id");
     }
 
-    public CohortDto convertToDto(Cohort cohort) {
-        CohortDto cohortDto = modelMapper.map(cohort, CohortDto.class);
-        CohortGroupDto cohortGroupDto = convertToCohortGroupDto(cohort.getCohortGroup());
-        cohortDto.setCohortGroupDto(cohortGroupDto);
-        return cohortDto;
+    cohort.setCohortGroup(convertToCohortGroupEntity(dto.getCohortGroupDto()));
+    return cohort;
+  }
+
+  private CohortGroup convertToCohortGroupEntity(CohortGroupDto dto) {
+    CohortGroup cohortGroup = modelMapper.map(dto, CohortGroup.class);
+    cohortGroup.setId(null);
+    if (dto.getType() == Type.PHENOTYPE) {
+      Optional<Phenotype> phenotype = phenotypeService.getPhenotypeById(dto.getPhenotypeId());
+
+      if (phenotype.isPresent()) {
+        cohortGroup.setPhenotype(phenotype.get());
+      } else {
+        throw new BadRequestException("Invalid phenotype id");
+      }
     }
 
-    public Cohort convertToEntity(CohortDto dto) {
-        Cohort cohort = modelMapper.map(dto, Cohort.class);
-        cohort.setId(null);
-        Optional<Study> study = studyService.getStudyById(dto.getStudyId());
-
-        if (study.isPresent()) {
-            cohort.setStudy(study.get());
-            study.get().setCohort(cohort);
-        } else {
-            throw new BadRequestException("Invalid study id");
-        }
-
-        cohort.setCohortGroup(convertToCohortGroupEntity(dto.getCohortGroupDto()));
-        return cohort;
+    if (dto.getType() == Type.GROUP) {
+      cohortGroup.setChildren(
+          dto.getChildren().stream()
+              .map(
+                  child -> {
+                    CohortGroup cohortGroupChild = convertToCohortGroupEntity(child);
+                    cohortGroupChild.setParent(cohortGroup);
+                    return cohortGroupChild;
+                  })
+              .collect(Collectors.toSet()));
     }
 
-    private CohortGroup convertToCohortGroupEntity(CohortGroupDto dto) {
-        CohortGroup cohortGroup = modelMapper.map(dto, CohortGroup.class);
-        cohortGroup.setId(null);
-        if (dto.getType() == Type.PHENOTYPE) {
-            Optional<Phenotype> phenotype = phenotypeService.getPhenotypeById(dto.getPhenotypeId());
+    return cohortGroup;
+  }
 
-            if (phenotype.isPresent()) {
-                cohortGroup.setPhenotype(phenotype.get());
-            } else {
-                throw new BadRequestException("Invalid phenotype id");
-            }
-
-        }
-
-        if (dto.getType() == Type.GROUP) {
-            cohortGroup.setChildren(dto.getChildren().stream().map(child -> {
-                CohortGroup cohortGroupChild = convertToCohortGroupEntity(child);
-                cohortGroupChild.setParent(cohortGroup);
-                return cohortGroupChild;
-            }).collect(Collectors.toSet()));
-        }
-
-        return cohortGroup;
+  private CohortGroupDto convertToCohortGroupDto(CohortGroup cohortGroup) {
+    CohortGroupDto dto = modelMapper.map(cohortGroup, CohortGroupDto.class);
+    if (cohortGroup.getType().equals(Type.GROUP)) {
+      dto.setChildren(
+          cohortGroup.getChildren().stream()
+              .map(this::convertToCohortGroupDto)
+              .collect(Collectors.toList()));
     }
-
-    private CohortGroupDto convertToCohortGroupDto(CohortGroup cohortGroup) {
-        CohortGroupDto dto = modelMapper.map(cohortGroup, CohortGroupDto.class);
-        if (cohortGroup.getType().equals(Type.GROUP)) {
-            dto.setChildren(cohortGroup.getChildren().stream().map(this::convertToCohortGroupDto).collect(Collectors.toList()));
-        }
-        return dto;
-    }
-
+    return dto;
+  }
 }

--- a/src/main/java/de/vitagroup/num/domain/Aql.java
+++ b/src/main/java/de/vitagroup/num/domain/Aql.java
@@ -18,24 +18,17 @@ import java.io.Serializable;
 @Builder
 public class Aql implements Serializable {
 
-    @ApiModelProperty(
-            required = true,
-            value = "The unique identifier",
-            example = "1")
-    @NotNull(message = "Id is mandatory")
-    private Long id;
+  @ApiModelProperty(required = true, value = "The unique identifier", example = "1")
+  @NotNull(message = "Id is mandatory")
+  private Long id;
 
-    @ApiModelProperty(
-            required = true,
-            value = "The AQL query")
-    @NotBlank(message = "Query is mandatory")
-    @NotNull(message = "Query is mandatory")
-    private String query;
+  @ApiModelProperty(required = true, value = "The AQL query")
+  @NotBlank(message = "Query is mandatory")
+  @NotNull(message = "Query is mandatory")
+  private String query;
 
-    @ApiModelProperty(
-            required = true,
-            value = "The name of the AQL query")
-    @NotNull(message = "Name is mandatory")
-    @NotBlank(message = "Name is mandatory")
-    private String name;
+  @ApiModelProperty(required = true, value = "The name of the AQL query")
+  @NotNull(message = "Name is mandatory")
+  @NotBlank(message = "Name is mandatory")
+  private String name;
 }

--- a/src/main/java/de/vitagroup/num/domain/AqlExpression.java
+++ b/src/main/java/de/vitagroup/num/domain/AqlExpression.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AqlExpression extends Expression {
 
-    private Aql aql;
+  private Aql aql;
 }

--- a/src/main/java/de/vitagroup/num/domain/Cohort.java
+++ b/src/main/java/de/vitagroup/num/domain/Cohort.java
@@ -14,19 +14,18 @@ import javax.persistence.*;
 @Builder
 public class Cohort {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    private String name;
+  private String name;
 
-    private String description;
+  private String description;
 
-    @OneToOne(mappedBy = "cohort")
-    private Study study;
+  @OneToOne(mappedBy = "cohort")
+  private Study study;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "cohort_group_id", referencedColumnName = "id")
-    private CohortGroup cohortGroup;
-
+  @OneToOne(cascade = CascadeType.ALL)
+  @JoinColumn(name = "cohort_group_id", referencedColumnName = "id")
+  private CohortGroup cohortGroup;
 }

--- a/src/main/java/de/vitagroup/num/domain/Expression.java
+++ b/src/main/java/de/vitagroup/num/domain/Expression.java
@@ -7,9 +7,7 @@ import java.io.Serializable;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = AqlExpression.class, name = "aql"),
-        @JsonSubTypes.Type(value = GroupExpression.class, name = "group")
+  @JsonSubTypes.Type(value = AqlExpression.class, name = "aql"),
+  @JsonSubTypes.Type(value = GroupExpression.class, name = "group")
 })
-public class Expression implements Serializable {
-
-}
+public class Expression implements Serializable {}

--- a/src/main/java/de/vitagroup/num/domain/GroupExpression.java
+++ b/src/main/java/de/vitagroup/num/domain/GroupExpression.java
@@ -14,8 +14,8 @@ import java.util.List;
 @AllArgsConstructor
 public class GroupExpression extends Expression {
 
-    @NotNull(message = "Operator mandatory")
-    private Operator operator;
+  @NotNull(message = "Operator mandatory")
+  private Operator operator;
 
-    private List<Expression> children;
+  private List<Expression> children;
 }

--- a/src/main/java/de/vitagroup/num/domain/Operator.java
+++ b/src/main/java/de/vitagroup/num/domain/Operator.java
@@ -1,5 +1,7 @@
 package de.vitagroup.num.domain;
 
 public enum Operator {
-    AND, OR, NOT;
+  AND,
+  OR,
+  NOT;
 }

--- a/src/main/java/de/vitagroup/num/domain/Phenotype.java
+++ b/src/main/java/de/vitagroup/num/domain/Phenotype.java
@@ -20,32 +20,22 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Builder
 public class Phenotype {
-    @ApiModelProperty(
-            required = true,
-            value = "The unique identifier",
-            example = "1")
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @ApiModelProperty(required = true, value = "The unique identifier", example = "1")
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @ApiModelProperty(
-            required = true,
-            value = "The name of the phenotype")
-    @NotBlank(message = "Phenotype name is mandatory")
-    private String name;
+  @ApiModelProperty(required = true, value = "The name of the phenotype")
+  @NotBlank(message = "Phenotype name is mandatory")
+  private String name;
 
-    @ApiModelProperty(
-            required = true,
-            value = "The description of the phenotype")
-    @NotBlank(message = "Phenotype description is mandatory")
-    private String description;
+  @ApiModelProperty(required = true, value = "The description of the phenotype")
+  @NotBlank(message = "Phenotype description is mandatory")
+  private String description;
 
-    @ApiModelProperty(
-            required = true,
-            value = "The aql query tree defining the phenotype")
-    @Convert(converter = ExpressionConverter.class)
-    @NotNull(message = "Query is mandatory")
-    @ValidExpression(message = "Invalid phenotype definition")
-    private Expression query;
-
+  @ApiModelProperty(required = true, value = "The aql query tree defining the phenotype")
+  @Convert(converter = ExpressionConverter.class)
+  @NotNull(message = "Query is mandatory")
+  @ValidExpression(message = "Invalid phenotype definition")
+  private Expression query;
 }

--- a/src/main/java/de/vitagroup/num/domain/Study.java
+++ b/src/main/java/de/vitagroup/num/domain/Study.java
@@ -14,15 +14,15 @@ import javax.persistence.*;
 @Builder
 public class Study {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    private String name;
-    
-    private String description;
+  private String name;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "cohort_id", referencedColumnName = "id")
-    private Cohort cohort;
+  private String description;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  @JoinColumn(name = "cohort_id", referencedColumnName = "id")
+  private Cohort cohort;
 }

--- a/src/main/java/de/vitagroup/num/domain/Type.java
+++ b/src/main/java/de/vitagroup/num/domain/Type.java
@@ -1,5 +1,6 @@
 package de.vitagroup.num.domain;
 
 public enum Type {
-    PHENOTYPE, GROUP;
+  PHENOTYPE,
+  GROUP;
 }

--- a/src/main/java/de/vitagroup/num/domain/repository/CohortGroupRepository.java
+++ b/src/main/java/de/vitagroup/num/domain/repository/CohortGroupRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CohortGroupRepository extends JpaRepository<CohortGroup, Long> {
-}
+public interface CohortGroupRepository extends JpaRepository<CohortGroup, Long> {}

--- a/src/test/java/de/vitagroup/num/domain/dto/CohortDtoTest.java
+++ b/src/test/java/de/vitagroup/num/domain/dto/CohortDtoTest.java
@@ -27,133 +27,223 @@ import java.util.Set;
 @RunWith(MockitoJUnitRunner.class)
 public class CohortDtoTest {
 
-    @Mock
-    private PhenotypeService phenotypeService;
+  @Mock private PhenotypeService phenotypeService;
 
-    @Mock
-    private StudyService studyService;
+  @Mock private StudyService studyService;
 
-    @Spy
-    private ModelMapper modelMapper;
+  @Spy private ModelMapper modelMapper;
 
-    @InjectMocks
-    private CohortConverter converter;
+  @InjectMocks private CohortConverter converter;
 
-    @Before
-    public void setup() {
-        Study study = Study.builder().id(1L).name("Study name").description("Study description").build();
+  @Before
+  public void setup() {
+    Study study =
+        Study.builder().id(1L).name("Study name").description("Study description").build();
 
-        Aql aql1 = Aql.builder().id(1L).name("AQL query name 1 ").query("SELECT A1 ... FROM E1... WHERE ...").build();
-        Aql aql2 = Aql.builder().id(2L).name("AQL query name 2").query("SELECT A2 ... FROM E2... WHERE ...").build();
+    Aql aql1 =
+        Aql.builder()
+            .id(1L)
+            .name("AQL query name 1 ")
+            .query("SELECT A1 ... FROM E1... WHERE ...")
+            .build();
+    Aql aql2 =
+        Aql.builder()
+            .id(2L)
+            .name("AQL query name 2")
+            .query("SELECT A2 ... FROM E2... WHERE ...")
+            .build();
 
-        AqlExpression aqlExpression1 = AqlExpression.builder().aql(aql1).build();
-        AqlExpression aqlExpression2 = AqlExpression.builder().aql(aql2).build();
+    AqlExpression aqlExpression1 = AqlExpression.builder().aql(aql1).build();
+    AqlExpression aqlExpression2 = AqlExpression.builder().aql(aql2).build();
 
-        Phenotype phenotype1 = Phenotype.builder().id(1L).name("Phenotype name").description("Phenotype description").query(aqlExpression1).build();
-        Phenotype phenotype2 = Phenotype.builder().id(2L).name("Phenotype name").description("Phenotype description").query(aqlExpression2).build();
+    Phenotype phenotype1 =
+        Phenotype.builder()
+            .id(1L)
+            .name("Phenotype name")
+            .description("Phenotype description")
+            .query(aqlExpression1)
+            .build();
+    Phenotype phenotype2 =
+        Phenotype.builder()
+            .id(2L)
+            .name("Phenotype name")
+            .description("Phenotype description")
+            .query(aqlExpression2)
+            .build();
 
-        when(studyService.getStudyById(any())).thenReturn(Optional.of(study));
-        when(phenotypeService.getPhenotypeById(1L)).thenReturn(Optional.of(phenotype1));
-        when(phenotypeService.getPhenotypeById(2L)).thenReturn(Optional.of(phenotype2));
-    }
+    when(studyService.getStudyById(any())).thenReturn(Optional.of(study));
+    when(phenotypeService.getPhenotypeById(1L)).thenReturn(Optional.of(phenotype1));
+    when(phenotypeService.getPhenotypeById(2L)).thenReturn(Optional.of(phenotype2));
+  }
 
-    @Test
-    public void shouldCorrectlyConvertCohortToCohortDto() {
-        Study study = Study.builder().id(1L).name("Study name").description("Study description").build();
+  @Test
+  public void shouldCorrectlyConvertCohortToCohortDto() {
+    Study study =
+        Study.builder().id(1L).name("Study name").description("Study description").build();
 
-        Aql aql1 = Aql.builder().id(1L).name("AQL query name 1 ").query("SELECT A1 ... FROM E1... WHERE ...").build();
-        Aql aql2 = Aql.builder().id(2L).name("AQL query name 2").query("SELECT A2 ... FROM E2... WHERE ...").build();
+    Aql aql1 =
+        Aql.builder()
+            .id(1L)
+            .name("AQL query name 1 ")
+            .query("SELECT A1 ... FROM E1... WHERE ...")
+            .build();
+    Aql aql2 =
+        Aql.builder()
+            .id(2L)
+            .name("AQL query name 2")
+            .query("SELECT A2 ... FROM E2... WHERE ...")
+            .build();
 
-        AqlExpression aqlExpression1 = AqlExpression.builder().aql(aql1).build();
-        AqlExpression aqlExpression2 = AqlExpression.builder().aql(aql2).build();
+    AqlExpression aqlExpression1 = AqlExpression.builder().aql(aql1).build();
+    AqlExpression aqlExpression2 = AqlExpression.builder().aql(aql2).build();
 
-        Phenotype phenotype1 = Phenotype.builder().id(1L).name("Phenotype name").description("Phenotype description").query(aqlExpression1).build();
-        Phenotype phenotype2 = Phenotype.builder().id(2L).name("Phenotype name").description("Phenotype description").query(aqlExpression2).build();
+    Phenotype phenotype1 =
+        Phenotype.builder()
+            .id(1L)
+            .name("Phenotype name")
+            .description("Phenotype description")
+            .query(aqlExpression1)
+            .build();
+    Phenotype phenotype2 =
+        Phenotype.builder()
+            .id(2L)
+            .name("Phenotype name")
+            .description("Phenotype description")
+            .query(aqlExpression2)
+            .build();
 
-        CohortGroup first = CohortGroup.builder().type(Type.PHENOTYPE).phenotype(phenotype1).build();
-        CohortGroup second = CohortGroup.builder().type(Type.PHENOTYPE).phenotype(phenotype2).build();
+    CohortGroup first = CohortGroup.builder().type(Type.PHENOTYPE).phenotype(phenotype1).build();
+    CohortGroup second = CohortGroup.builder().type(Type.PHENOTYPE).phenotype(phenotype2).build();
 
-        CohortGroup andCohort = CohortGroup.builder().type(Type.GROUP).operator(Operator.AND).children(Set.of(first, second)).build();
+    CohortGroup andCohort =
+        CohortGroup.builder()
+            .type(Type.GROUP)
+            .operator(Operator.AND)
+            .children(Set.of(first, second))
+            .build();
 
-        Cohort cohort = Cohort.builder().name("Cohort name").study(study).cohortGroup(andCohort).build();
-        CohortDto cohortDto = converter.convertToDto(cohort);
+    Cohort cohort =
+        Cohort.builder().name("Cohort name").study(study).cohortGroup(andCohort).build();
+    CohortDto cohortDto = converter.convertToDto(cohort);
 
-        assertThat(cohortDto.getName(), notNullValue());
-        assertThat(cohortDto.getName(), is("Cohort name"));
+    assertThat(cohortDto.getName(), notNullValue());
+    assertThat(cohortDto.getName(), is("Cohort name"));
 
-        assertThat(cohortDto.getStudyId(), is(study.getId()));
+    assertThat(cohortDto.getStudyId(), is(study.getId()));
 
-        assertThat(cohortDto.getCohortGroupDto(), notNullValue());
-        assertThat(cohortDto.getCohortGroupDto().getType(), is(Type.GROUP));
-        assertThat(cohortDto.getCohortGroupDto().getOperator(), is(Operator.AND));
-        assertThat(cohortDto.getCohortGroupDto().getChildren().size(), is(2));
+    assertThat(cohortDto.getCohortGroupDto(), notNullValue());
+    assertThat(cohortDto.getCohortGroupDto().getType(), is(Type.GROUP));
+    assertThat(cohortDto.getCohortGroupDto().getOperator(), is(Operator.AND));
+    assertThat(cohortDto.getCohortGroupDto().getChildren().size(), is(2));
 
-        assertThat(cohortDto.getCohortGroupDto().getChildren().get(0).getType(), is(Type.PHENOTYPE));
-        assertThat(cohortDto.getCohortGroupDto().getChildren().get(1).getType(), is(Type.PHENOTYPE));
+    assertThat(cohortDto.getCohortGroupDto().getChildren().get(0).getType(), is(Type.PHENOTYPE));
+    assertThat(cohortDto.getCohortGroupDto().getChildren().get(1).getType(), is(Type.PHENOTYPE));
 
-        assertThat(cohortDto.getCohortGroupDto().getChildren().stream().anyMatch(c -> c.getPhenotypeId() == 1), is(true));
-        assertThat(cohortDto.getCohortGroupDto().getChildren().stream().anyMatch(c -> c.getPhenotypeId() == 2), is(true));
-    }
+    assertThat(
+        cohortDto.getCohortGroupDto().getChildren().stream().anyMatch(c -> c.getPhenotypeId() == 1),
+        is(true));
+    assertThat(
+        cohortDto.getCohortGroupDto().getChildren().stream().anyMatch(c -> c.getPhenotypeId() == 2),
+        is(true));
+  }
 
-    @Test
-    public void shouldCorrectlyConvertCohortDtoToCohort() {
-        CohortGroupDto first = CohortGroupDto.builder().type(Type.PHENOTYPE).phenotypeId(1L).build();
-        CohortGroupDto second = CohortGroupDto.builder().type(Type.PHENOTYPE).phenotypeId(2L).build();
+  @Test
+  public void shouldCorrectlyConvertCohortDtoToCohort() {
+    CohortGroupDto first = CohortGroupDto.builder().type(Type.PHENOTYPE).phenotypeId(1L).build();
+    CohortGroupDto second = CohortGroupDto.builder().type(Type.PHENOTYPE).phenotypeId(2L).build();
 
-        CohortGroupDto andCohort = CohortGroupDto.builder().type(Type.GROUP).operator(Operator.AND).children(List.of(first, second)).build();
+    CohortGroupDto andCohort =
+        CohortGroupDto.builder()
+            .type(Type.GROUP)
+            .operator(Operator.AND)
+            .children(List.of(first, second))
+            .build();
 
-        CohortDto cohortDto = CohortDto.builder().name("Cohort name").studyId(1L).cohortGroupDto(andCohort).build();
-        Cohort cohort = converter.convertToEntity(cohortDto);
+    CohortDto cohortDto =
+        CohortDto.builder().name("Cohort name").studyId(1L).cohortGroupDto(andCohort).build();
+    Cohort cohort = converter.convertToEntity(cohortDto);
 
-        assertThat(cohort, notNullValue());
-        assertThat(cohort.getStudy(), notNullValue());
-        assertThat(cohort.getStudy().getId(), is(1L));
-        assertThat(cohort.getStudy().getName(), is("Study name"));
-        assertThat(cohort.getCohortGroup().getOperator(), is(Operator.AND));
-        assertThat(cohort.getCohortGroup().getType(), is(Type.GROUP));
-        assertThat(cohort.getCohortGroup().getChildren().size(), is(2));
+    assertThat(cohort, notNullValue());
+    assertThat(cohort.getStudy(), notNullValue());
+    assertThat(cohort.getStudy().getId(), is(1L));
+    assertThat(cohort.getStudy().getName(), is("Study name"));
+    assertThat(cohort.getCohortGroup().getOperator(), is(Operator.AND));
+    assertThat(cohort.getCohortGroup().getType(), is(Type.GROUP));
+    assertThat(cohort.getCohortGroup().getChildren().size(), is(2));
 
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getPhenotype().getId() == 1), is(true));
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getPhenotype().getId() == 2), is(true));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getPhenotype().getId() == 1),
+        is(true));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getPhenotype().getId() == 2),
+        is(true));
 
-        assertThat(cohort.getCohortGroup().getChildren().stream().allMatch(c -> c.getPhenotype().getQuery() instanceof AqlExpression), is(true));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream()
+            .allMatch(c -> c.getPhenotype().getQuery() instanceof AqlExpression),
+        is(true));
+  }
 
-    }
+  @Test
+  public void shouldNotCopyIdsFromCohortDtoToCohort() {
+    CohortGroupDto first =
+        CohortGroupDto.builder().id(1L).type(Type.PHENOTYPE).phenotypeId(1L).build();
+    CohortGroupDto second =
+        CohortGroupDto.builder().id(2L).type(Type.PHENOTYPE).phenotypeId(2L).build();
 
+    CohortGroupDto andCohort =
+        CohortGroupDto.builder()
+            .id(12L)
+            .type(Type.GROUP)
+            .operator(Operator.AND)
+            .children(List.of(first, second))
+            .build();
 
-    @Test
-    public void shouldNotCopyIdsFromCohortDtoToCohort() {
-        CohortGroupDto first = CohortGroupDto.builder().id(1L).type(Type.PHENOTYPE).phenotypeId(1L).build();
-        CohortGroupDto second = CohortGroupDto.builder().id(2L).type(Type.PHENOTYPE).phenotypeId(2L).build();
+    CohortDto cohortDto =
+        CohortDto.builder()
+            .id(16L)
+            .name("Cohort name")
+            .studyId(1L)
+            .cohortGroupDto(andCohort)
+            .build();
 
-        CohortGroupDto andCohort = CohortGroupDto.builder().id(12L).type(Type.GROUP).operator(Operator.AND).children(List.of(first, second)).build();
+    Cohort cohort = converter.convertToEntity(cohortDto);
 
-        CohortDto cohortDto = CohortDto.builder().id(16L).name("Cohort name").studyId(1L).cohortGroupDto(andCohort).build();
+    assertThat(cohort, notNullValue());
+    assertThat(cohort.getId(), is(nullValue()));
+    assertThat(cohort.getCohortGroup().getId(), is(nullValue()));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == null), is(true));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == null), is(true));
+  }
 
-        Cohort cohort = converter.convertToEntity(cohortDto);
+  @Test
+  public void shouldCopyIdsFromCohortToCohortDto() {
 
-        assertThat(cohort, notNullValue());
-        assertThat(cohort.getId(), is(nullValue()));
-        assertThat(cohort.getCohortGroup().getId(), is(nullValue()));
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == null), is(true));
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == null), is(true));
-    }
+    CohortGroup first = CohortGroup.builder().id(1L).type(Type.PHENOTYPE).phenotype(null).build();
+    CohortGroup second = CohortGroup.builder().id(2L).type(Type.PHENOTYPE).phenotype(null).build();
 
-    @Test
-    public void shouldCopyIdsFromCohortToCohortDto() {
+    CohortGroup andCohort =
+        CohortGroup.builder()
+            .id(12L)
+            .type(Type.GROUP)
+            .operator(Operator.AND)
+            .children(Set.of(first, second))
+            .build();
 
-        CohortGroup first = CohortGroup.builder().id(1L).type(Type.PHENOTYPE).phenotype(null).build();
-        CohortGroup second = CohortGroup.builder().id(2L).type(Type.PHENOTYPE).phenotype(null).build();
+    Cohort cohort =
+        Cohort.builder().name("Cohort name").id(17L).study(null).cohortGroup(andCohort).build();
+    CohortDto cohortDto = converter.convertToDto(cohort);
 
-        CohortGroup andCohort = CohortGroup.builder().id(12L).type(Type.GROUP).operator(Operator.AND).children(Set.of(first, second)).build();
-
-        Cohort cohort = Cohort.builder().name("Cohort name").id(17L).study(null).cohortGroup(andCohort).build();
-        CohortDto cohortDto = converter.convertToDto(cohort);
-
-        assertThat(cohortDto, notNullValue());
-        assertThat(cohortDto.getId(), is(cohort.getId()));
-        assertThat(cohortDto.getCohortGroupDto().getId(), is(andCohort.getId()));
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == first.getId()), is(true));
-        assertThat(cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == second.getId()), is(true));
-    }
+    assertThat(cohortDto, notNullValue());
+    assertThat(cohortDto.getId(), is(cohort.getId()));
+    assertThat(cohortDto.getCohortGroupDto().getId(), is(andCohort.getId()));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == first.getId()),
+        is(true));
+    assertThat(
+        cohort.getCohortGroup().getChildren().stream().anyMatch(c -> c.getId() == second.getId()),
+        is(true));
+  }
 }


### PR DESCRIPTION
ModelMapper mapper.skip() doesn't work for pojo objects with circular dependency so I am manually setting the ids to null at conversion