### PR TITLE
Feature/num 1952 user not shown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <commons-csv.version>1.8</commons-csv.version>
     <jacoco.version>0.8.7</jacoco.version>
     <dependency-check.version>6.2.2</dependency-check.version>
-    <failsafe.version>2.22.2</failsafe.version>
-    <surefire.version>2.22.2</surefire.version>
+    <failsafe.version>3.0.0-M5</failsafe.version>
+    <surefire.version>3.0.0-M5</surefire.version>
     <ehcache.version>3.9.4</ehcache.version>
     <git-commit-id-plugin.version>4.9.9</git-commit-id-plugin.version>
     <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/de/vitagroup/num/service/UserService.java
+++ b/src/main/java/de/vitagroup/num/service/UserService.java
@@ -8,8 +8,8 @@ import de.vitagroup.num.domain.dto.UserNameDto;
 import de.vitagroup.num.mapper.OrganizationMapper;
 import de.vitagroup.num.service.notification.NotificationService;
 import de.vitagroup.num.service.notification.dto.Notification;
-import de.vitagroup.num.service.notification.dto.account.UserNameUpdateNotification;
 import de.vitagroup.num.service.notification.dto.account.RolesUpdateNotification;
+import de.vitagroup.num.service.notification.dto.account.UserNameUpdateNotification;
 import de.vitagroup.num.web.exception.BadRequestException;
 import de.vitagroup.num.web.exception.ForbiddenException;
 import de.vitagroup.num.web.exception.ResourceNotFound;
@@ -40,6 +40,8 @@ import org.springframework.stereotype.Service;
 @Service
 @AllArgsConstructor
 public class UserService {
+
+  private static final int MAX_USER_COUNT = 100000;
 
   private final KeycloakFeign keycloakFeign;
 
@@ -137,7 +139,7 @@ public class UserService {
   /**
    * Assigns roles to a particular user
    *
-   * @param userId the user to update roles of
+   * @param userId    the user to update roles of
    * @param roleNames The list of roles of the user
    */
   public List<String> setUserRoles(
@@ -156,9 +158,9 @@ public class UserService {
     if (callerRoles.contains(Roles.ORGANIZATION_ADMIN)
         && !callerRoles.contains(Roles.SUPER_ADMIN)
         && !callerDetails
-            .getOrganization()
-            .getId()
-            .equals(userToChange.getOrganization().getId())) {
+        .getOrganization()
+        .getId()
+        .equals(userToChange.getOrganization().getId())) {
       throw new ForbiddenException(
           "Organization admin can only manage users in their own organization.");
     }
@@ -256,8 +258,8 @@ public class UserService {
   /**
    * Retrieved a list of users that match the search criteria
    *
-   * @param approved Indicates that the user has been approved by the admin
-   * @param search A string contained in username, first or last name, or email
+   * @param approved  Indicates that the user has been approved by the admin
+   * @param search    A string contained in username, first or last name, or email
    * @param withRoles flag whether to add roles to the user structure, if present, or not
    * @return the users that match the search parameters and with optional roles if indicated
    */
@@ -270,7 +272,7 @@ public class UserService {
 
     UserDetails loggedInUser = userDetailsService.checkIsUserApproved(loggedInUserId);
 
-    Set<User> users = keycloakFeign.searchUsers(search);
+    Set<User> users = keycloakFeign.searchUsers(search, MAX_USER_COUNT);
     if (users == null) {
       return Collections.emptySet();
     }
@@ -397,7 +399,9 @@ public class UserService {
     }
   }
 
-  /** Evicts users cache every 8 hours */
+  /**
+   * Evicts users cache every 8 hours
+   */
   @Scheduled(fixedRate = 28800000)
   public void evictParametersCache() {
     var cache = cacheManager.getCache(USERS_CACHE);
@@ -419,7 +423,7 @@ public class UserService {
     if (Roles.isSuperAdmin(roles)
         || isSelf(loggedInUser, userToChange)
         || (Roles.isOrganizationAdmin(roles)
-            && belongToSameOrganization(loggedInUser, userToChange))) {
+        && belongToSameOrganization(loggedInUser, userToChange))) {
       updateName(userIdToChange, userName);
     } else {
       throw new ForbiddenException(

--- a/src/main/java/de/vitagroup/num/web/feign/KeycloakFeign.java
+++ b/src/main/java/de/vitagroup/num/web/feign/KeycloakFeign.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "keycloak", url = "${userstore.url}")
 public interface KeycloakFeign {
+
   @GetMapping("/users/{userId}")
   User getUser(@PathVariable String userId);
 
@@ -34,7 +35,7 @@ public interface KeycloakFeign {
   Set<Role> getRoles();
 
   @GetMapping("/users")
-  Set<User> searchUsers(@RequestParam(required = false) String search);
+  Set<User> searchUsers(@RequestParam(required = false) String search, @RequestParam int max);
 
   @GetMapping("/roles/{roleName}/users")
   Set<User> getByRole(@PathVariable String roleName);

--- a/src/test/java/de/vitagroup/num/service/UserServiceTest.java
+++ b/src/test/java/de/vitagroup/num/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -56,23 +57,32 @@ import org.modelmapper.ModelMapper;
 @RunWith(MockitoJUnitRunner.class)
 public class UserServiceTest {
 
-  @Mock private KeycloakFeign keycloakFeign;
+  @Mock
+  private KeycloakFeign keycloakFeign;
 
-  @Mock private UserDetailsService userDetailsService;
+  @Mock
+  private UserDetailsService userDetailsService;
 
-  @Mock private NotificationService notificationService;
+  @Mock
+  private NotificationService notificationService;
 
-  @Spy private final ModelMapper modelMapper = new ModelMapper();
+  @Spy
+  private final ModelMapper modelMapper = new ModelMapper();
 
-  @Spy private final OrganizationMapper organizationMapper = new OrganizationMapper(modelMapper);
+  @Spy
+  private final OrganizationMapper organizationMapper = new OrganizationMapper(modelMapper);
 
-  @InjectMocks private UserService userService;
+  @InjectMocks
+  private UserService userService;
 
-  @Captor ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
+  @Captor
+  ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
 
-  @Captor ArgumentCaptor<String> stringArgumentCaptor;
+  @Captor
+  ArgumentCaptor<String> stringArgumentCaptor;
 
-  @Captor ArgumentCaptor<List<Notification>> notificationCaptor;
+  @Captor
+  ArgumentCaptor<List<Notification>> notificationCaptor;
 
   private final Set<Role> roles =
       Set.of(
@@ -113,7 +123,7 @@ public class UserServiceTest {
 
     when(keycloakFeign.getRoles()).thenReturn(roles);
 
-    when(keycloakFeign.searchUsers(any())).thenReturn(allValidUsers);
+    when(keycloakFeign.searchUsers(any(), eq(100000))).thenReturn(allValidUsers);
 
     when(userDetailsService.getUserDetailsById("4"))
         .thenReturn(
@@ -326,7 +336,7 @@ public class UserServiceTest {
     Set<User> users = new HashSet<>();
     users.add(User.builder().firstName("John").id("4").build());
 
-    when(keycloakFeign.searchUsers(null)).thenReturn(users);
+    when(keycloakFeign.searchUsers(null, 100000)).thenReturn(users);
     Set<de.vitagroup.num.domain.admin.User> userReturn =
         userService.searchUsers("user", null, null, true, List.of(Roles.SUPER_ADMIN));
 
@@ -346,7 +356,7 @@ public class UserServiceTest {
     Set<User> users = new HashSet<>();
     users.add(User.builder().firstName("John").id("4").build());
 
-    when(keycloakFeign.searchUsers(null)).thenReturn(users);
+    when(keycloakFeign.searchUsers(null, 100000)).thenReturn(users);
     Set<de.vitagroup.num.domain.admin.User> userReturn =
         userService.searchUsers("user", null, null, false, List.of(Roles.SUPER_ADMIN));
 
@@ -477,8 +487,8 @@ public class UserServiceTest {
         boolean success = testAddRole(role, userRole.getName());
         if (userRole.getName().equals("SUPER_ADMIN")
             || (userRole.getName().equals("ORGANIZATION_ADMIN")
-                && !role.getName().equals("SUPER_ADMIN")
-                && !role.getName().equals("CONTENT_ADMIN"))) {
+            && !role.getName().equals("SUPER_ADMIN")
+            && !role.getName().equals("CONTENT_ADMIN"))) {
           assertTrue(
               success,
               "User " + userRole.getName() + " should be allowed to add role " + role.getName());
@@ -501,8 +511,8 @@ public class UserServiceTest {
         boolean success = testRemoveRole(role, userRole.getName());
         if (userRole.getName().equals("SUPER_ADMIN")
             || (userRole.getName().equals("ORGANIZATION_ADMIN")
-                && !role.getName().equals("SUPER_ADMIN")
-                && !role.getName().equals("CONTENT_ADMIN"))) {
+            && !role.getName().equals("SUPER_ADMIN")
+            && !role.getName().equals("CONTENT_ADMIN"))) {
           assertTrue(
               success,
               "User " + userRole.getName() + " should be allowed to remove role " + role.getName());
@@ -524,8 +534,8 @@ public class UserServiceTest {
           "5", Collections.singletonList(role.getName()), "4", Collections.singletonList(userRole));
       if (userRole.equals("SUPER_ADMIN")
           || (userRole.equals("ORGANIZATION_ADMIN")
-              && !"SUPER_ADMIN".equals(role.getName())
-              && !"CONTENT_ADMIN".equals(role.getName()))) {
+          && !"SUPER_ADMIN".equals(role.getName())
+          && !"CONTENT_ADMIN".equals(role.getName()))) {
         verify(keycloakFeign, times(1)).addRoles("5", new Role[] {role});
         Mockito.clearInvocations(keycloakFeign);
         return true;
@@ -554,8 +564,8 @@ public class UserServiceTest {
           "6", allButWantedToRemoveRoles, "4", Collections.singletonList(userRole));
       if (userRole.equals("SUPER_ADMIN")
           || (userRole.equals("ORGANIZATION_ADMIN")
-              && !"SUPER_ADMIN".equals(role.getName())
-              && !"CONTENT_ADMIN".equals(role.getName()))) {
+          && !"SUPER_ADMIN".equals(role.getName())
+          && !"CONTENT_ADMIN".equals(role.getName()))) {
         verify(keycloakFeign, times(1)).removeRoles("6", new Role[] {role});
         Mockito.clearInvocations(keycloakFeign);
         return true;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -73,8 +73,8 @@ feign:
   client:
     config:
       numPortal:
-        connectTimeout: 1000
-        readTimeout: 1200
+        connectTimeout: 10000
+        readTimeout: 10000
         loggerLevel: FULL
 
 logging:


### PR DESCRIPTION
fix (NUM-1952) user not shown

- keycloak user limit for the admin api was set to default (100) so not all users could be retrieved -> increased limit to 100000 and feign timeouts to 10000ms.
- updated surefire plugin to 3.0.0-M5