### PR TITLE
disable temporarly deploy env variables

### DIFF
--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -72,8 +72,8 @@ num:
 consent:
   allow-usage-outside-eu-oid: ${ALLOW_USAGE_OUTSIDE_EU_OID}
 
-fttp:
-  url: ${FTTP_URL}
+#fttp:
+#  url: ${FTTP_URL}
 #  certificatePath: ${FTTP_CERT_PATH}
 #  certificateKey: ${FTTP_CERT_PASSWORD}
 #  useBasicAuth: ${FTTP_USE_BASIC_AUTH}

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -74,16 +74,16 @@ consent:
 
 fttp:
   url: ${FTTP_URL}
-  certificatePath: ${FTTP_CERT_PATH}
-  certificateKey: ${FTTP_CERT_PASSWORD}
-  useBasicAuth: ${FTTP_USE_BASIC_AUTH}
-  username: ${FTTP_USERNAME}
-  password: ${FTTP_PASSWORD}
-
-requestpsnworkflow:
-  params:
-    study: ${PSNWORKFLOW_STUDY}
-    source: ${PSNWORKFLOW_SOURCE}
-    target: ${PSNWORKFLOW_TARGET}
-    apikey: ${PSNWORKFLOW_API_KEY}
-    event: ${PSNWORKFLOW_EVENT}
+#  certificatePath: ${FTTP_CERT_PATH}
+#  certificateKey: ${FTTP_CERT_PASSWORD}
+#  useBasicAuth: ${FTTP_USE_BASIC_AUTH}
+#  username: ${FTTP_USERNAME}
+#  password: ${FTTP_PASSWORD}
+#
+#requestpsnworkflow:
+#  params:
+#    study: ${PSNWORKFLOW_STUDY}
+#    source: ${PSNWORKFLOW_SOURCE}
+#    target: ${PSNWORKFLOW_TARGET}
+#    apikey: ${PSNWORKFLOW_API_KEY}
+#    event: ${PSNWORKFLOW_EVENT}


### PR DESCRIPTION
disable for the moment in order to use already configured values in application.yaml