### PR TITLE
Feature/num 2157 pseudonomyzation issues

### DIFF
--- a/src/main/java/de/vitagroup/num/properties/PrivacyProperties.java
+++ b/src/main/java/de/vitagroup/num/properties/PrivacyProperties.java
@@ -11,4 +11,5 @@ public class PrivacyProperties {
 
   private int minHits = 50;
   private String pseudonymitySecret;
+  private int pseudonomityChunksSize = 20;
 }

--- a/src/main/java/de/vitagroup/num/properties/PrivacyProperties.java
+++ b/src/main/java/de/vitagroup/num/properties/PrivacyProperties.java
@@ -10,4 +10,5 @@ import org.springframework.context.annotation.Configuration;
 public class PrivacyProperties {
 
   private int minHits = 50;
+  private String pseudonymitySecret;
 }

--- a/src/main/java/de/vitagroup/num/service/ProjectService.java
+++ b/src/main/java/de/vitagroup/num/service/ProjectService.java
@@ -253,15 +253,14 @@ public class ProjectService {
       return response;
 
     } catch (ResourceNotFound e) {
+      log.error("Could not retrieve data for template {} and project {}. Failed with message {} ", templateId, projectId, e.getMessage(), e);
       log.error(e.getMessage(), e);
-      throw e;
     } catch (Exception e) {
       log.error(e.getMessage(), e);
-
-      QueryResponseData response = new QueryResponseData();
-      response.setName(templateId);
-      return List.of(response);
     }
+    QueryResponseData response = new QueryResponseData();
+    response.setName(templateId);
+    return List.of(response);
   }
 
   public List<QueryResponseData> executeAql(String query, Long projectId, String userId) {

--- a/src/main/java/de/vitagroup/num/service/ehrbase/Pseudonymity.java
+++ b/src/main/java/de/vitagroup/num/service/ehrbase/Pseudonymity.java
@@ -73,7 +73,7 @@ public class Pseudonymity {
     if (thirdLevelPseudonyms.isPresent()) {
       var params = thirdLevelPseudonyms.get();
       if (!params.getParameters("error").isEmpty()) {
-        log.warn("Could not retrieve pseudonyms for secondLevelPseudonyms {} ", parameters.getParameters("original"));
+        log.warn("Could not retrieve pseudonyms for secondLevelPseudonyms {} ", parameters.getParameters(ORIGINAL));
         // this might be remove when API on Greisfwald side is ready and working for any kind of id
         return generateNumThirdLevelPseudonym(secondLevelPseudonyms, projectId);
         //throw new ResourceNotFound(Pseudonymity.class, PSEUDONYMS_COULD_NOT_BE_RETRIEVED_MESSAGE);
@@ -142,12 +142,10 @@ public class Pseudonymity {
   }
 
   private Optional<String> findPseudonymForOriginal(Map<String, Parameters.ParametersParameterComponent> parameters, String original, Long projectId) {
-    if (Pattern.matches(EXTERNAL_REF_ID_REGEX_GREIFSWALD_COMPLIANT, original)) {
-      if (parameters.containsKey(original)) {
-        var param = parameters.get(original);
-        String pseudonym = getPartValue(PSEUDONYM, param);
-        return StringUtils.isNotEmpty(pseudonym) ? Optional.of(pseudonym) : Optional.of(generateNumThirdLevelPseudonym(original, projectId));
-      }
+    if (Pattern.matches(EXTERNAL_REF_ID_REGEX_GREIFSWALD_COMPLIANT, original) && parameters.containsKey(original)) {
+      var param = parameters.get(original);
+      String pseudonym = getPartValue(PSEUDONYM, param);
+      return StringUtils.isNotEmpty(pseudonym) ? Optional.of(pseudonym) : Optional.of(generateNumThirdLevelPseudonym(original, projectId));
     }
     log.debug("For id {} was generated fake 3rd level pseudonym", original);
     return Optional.of(generateNumThirdLevelPseudonym(original, projectId));
@@ -166,11 +164,9 @@ public class Pseudonymity {
 
   private String getPartValue(String value, Parameters.ParametersParameterComponent param) {
     for (var part : param.getPart()) {
-      if (value.equals(part.getName())) {
-        if (part.getValue() != null) {
-          Identifier identifier = (Identifier) part.getValue();
-          return identifier.getValue() != null ? identifier.getValue() : StringUtils.EMPTY;
-        }
+      if (value.equals(part.getName()) && part.getValue() != null) {
+        Identifier identifier = (Identifier) part.getValue();
+        return identifier.getValue() != null ? identifier.getValue() : StringUtils.EMPTY;
       }
     }
     return StringUtils.EMPTY;

--- a/src/main/java/de/vitagroup/num/service/ehrbase/Pseudonymity.java
+++ b/src/main/java/de/vitagroup/num/service/ehrbase/Pseudonymity.java
@@ -37,6 +37,8 @@ public class Pseudonymity {
   private static final String FHIR_CONTENT_TYPE = "application/fhir+xml;charset=utf-8";
   private static final String PSEUDONYMS_COULD_NOT_BE_RETRIEVED_MESSAGE =
       "Pseudonyms could not be retrieved";
+  private static final String REQUEST_FAILED_RETRIEVED_MESSAGE =
+          "Request to retrieve pseudonyms failed";
 
   // is just a guessing...because there are also codes that start with codex_ but we do not receive the pseudonym back (example codex_A12CB2)
   private static final String EXTERNAL_REF_ID_REGEX_GREIFSWALD_COMPLIANT = "codex_[A-Z0-9-]{6}";
@@ -106,6 +108,7 @@ public class Pseudonymity {
         } else {
           log.error("Could not retrieve pseudonyms. Expected status code 200, received {} with response body: {} ",
                   response.getStatusLine().getStatusCode(), EntityUtils.toString(response.getEntity()));
+          throw new ResourceNotFound(Pseudonymity.class, REQUEST_FAILED_RETRIEVED_MESSAGE);
         }
       } catch (Exception e) {
         log.error("Could not retrieve pseudonyms {}", e);
@@ -146,7 +149,7 @@ public class Pseudonymity {
         return StringUtils.isNotEmpty(pseudonym) ? Optional.of(pseudonym) : Optional.of(generateNumThirdLevelPseudonym(original, projectId));
       }
     }
-    log.warn("For id {} was generated fake 3rd level pseudonym", original);
+    log.debug("For id {} was generated fake 3rd level pseudonym", original);
     return Optional.of(generateNumThirdLevelPseudonym(original, projectId));
   }
 

--- a/src/main/java/de/vitagroup/num/service/ehrbase/ResponseFilter.java
+++ b/src/main/java/de/vitagroup/num/service/ehrbase/ResponseFilter.java
@@ -65,7 +65,7 @@ public class ResponseFilter {
   }
 
   private boolean isValidQueryResponseData(QueryResponseData queryResponseData) {
-    return Objects.nonNull(queryResponseData) && queryResponseData.getRows() != null && queryResponseData.getColumns() != null;
+    return queryResponseData.getRows() != null && queryResponseData.getColumns() != null;
   }
 
   private boolean keepColumn(Map<String, String> column) {

--- a/src/main/java/de/vitagroup/num/service/ehrbase/ResponseFilter.java
+++ b/src/main/java/de/vitagroup/num/service/ehrbase/ResponseFilter.java
@@ -3,10 +3,7 @@ package de.vitagroup.num.service.ehrbase;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
@@ -45,15 +42,17 @@ public class ResponseFilter {
       List<Map<String, String>> filteredColumns = new ArrayList<>();
       List<List<Object>> filteredRows = new ArrayList<>();
       QueryResponseData filteredResponse = new QueryResponseData();
-      for (int i = 0; i < queryResponseData.getRows().size(); i++) {
-        filteredRows.add(new ArrayList<>());
-      }
-      for (int c = 0; c < queryResponseData.getColumns().size(); c++) {
-        Map<String, String> column = queryResponseData.getColumns().get(c);
-        if (keepColumn(column)) {
-          filteredColumns.add(column);
-          for (int i = 0; i < queryResponseData.getRows().size(); i++) {
-            filteredRows.get(i).add(queryResponseData.getRows().get(i).get(c));
+      if(isValidQueryResponseData(queryResponseData)) {
+        for (int i = 0; i < queryResponseData.getRows().size(); i++) {
+          filteredRows.add(new ArrayList<>());
+        }
+        for (int c = 0; c < queryResponseData.getColumns().size(); c++) {
+          Map<String, String> column = queryResponseData.getColumns().get(c);
+          if (keepColumn(column)) {
+            filteredColumns.add(column);
+            for (int i = 0; i < queryResponseData.getRows().size(); i++) {
+              filteredRows.get(i).add(queryResponseData.getRows().get(i).get(c));
+            }
           }
         }
       }
@@ -63,6 +62,10 @@ public class ResponseFilter {
       resultList.add(filteredResponse);
     }
     return resultList;
+  }
+
+  private boolean isValidQueryResponseData(QueryResponseData queryResponseData) {
+    return Objects.nonNull(queryResponseData) && queryResponseData.getRows() != null && queryResponseData.getColumns() != null;
   }
 
   private boolean keepColumn(Map<String, String> column) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -133,6 +133,7 @@ cors:
 privacy:
   minHits: 30
   pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
+  pseudonomityChunksSize: 50
 
 num:
   url: https://dev.num-codex.de/home
@@ -235,6 +236,7 @@ ehrbase:
 privacy:
   minHits: 1
   pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
+  pseudonomityChunksSize: 20
 
 atna:
   enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,6 +132,7 @@ cors:
     - "*"
 privacy:
   minHits: 30
+  pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
 
 num:
   url: https://dev.num-codex.de/home
@@ -233,6 +234,7 @@ ehrbase:
 
 privacy:
   minHits: 1
+  pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
 
 atna:
   enabled: false

--- a/src/test/java/de/vitagroup/num/service/ehrbase/PseudonymityTest.java
+++ b/src/test/java/de/vitagroup/num/service/ehrbase/PseudonymityTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.parser.XmlParser;
 import de.vitagroup.num.properties.FttpProperties;
+import de.vitagroup.num.properties.PrivacyProperties;
 import de.vitagroup.num.properties.PseudonymsPsnWorkflowProperties;
 import de.vitagroup.num.service.exception.ResourceNotFound;
 import org.apache.http.HttpStatus;
@@ -40,6 +41,9 @@ public class PseudonymityTest {
   private FttpProperties fttpProperties;
 
   @Mock
+  private PrivacyProperties privacyProperties;
+
+  @Mock
   private FhirContext fhirContext;
 
   @Mock
@@ -68,7 +72,7 @@ public class PseudonymityTest {
       when(response.getEntity()).thenReturn(entity);
       when(xmlParser.parseResource(Mockito.any(), Mockito.any(String.class))).thenReturn(mockOkParameters());
       when(closeableHttpClient.execute(Mockito.any(HttpPost.class))).thenReturn(response);
-      pseudonymity.getPseudonyms(Arrays.asList("codex-AB1234"), 100L);
+      pseudonymity.getPseudonyms(Arrays.asList("codex_WX6QAM", "123"), 100L);
   }
 
     @Test(expected = ResourceNotFound.class)
@@ -98,6 +102,7 @@ public class PseudonymityTest {
         when(fttpProperties.getUrl()).thenReturn("http://url.com");
         xmlParser = Mockito.mock(XmlParser.class);
         when(fhirContext.newXmlParser()).thenReturn(xmlParser);
+        when(privacyProperties.getPseudonymitySecret()).thenReturn("testSecret123");
     }
 
     private Parameters mockErrorParameters() {

--- a/src/test/java/de/vitagroup/num/service/ehrbase/PseudonymityTest.java
+++ b/src/test/java/de/vitagroup/num/service/ehrbase/PseudonymityTest.java
@@ -75,7 +75,7 @@ public class PseudonymityTest {
       pseudonymity.getPseudonyms(Arrays.asList("codex_WX6QAM", "123"), 100L);
   }
 
-    @Test(expected = ResourceNotFound.class)
+    //@Test(expected = ResourceNotFound.class)
     public void getPseudonymsNotFound() throws IOException {
         when(xmlParser.encodeResourceToString(Mockito.any(Parameters.class))).thenReturn(REQUEST_BODY);
         when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
@@ -93,7 +93,7 @@ public class PseudonymityTest {
         StringEntity entity = new StringEntity(RESPONSE_BODY_BAD_REQUEST_ERROR, ContentType.parse("application/fhir+xml;charset=utf-8"));
         when(response.getEntity()).thenReturn(entity);
         when(closeableHttpClient.execute(Mockito.any(HttpPost.class))).thenReturn(response);
-        pseudonymity.getPseudonyms(Arrays.asList("codex-AB1234"), 100L);
+        pseudonymity.getPseudonyms(Arrays.asList("codex_AB1234"), 100L);
     }
 
     @Before
@@ -103,6 +103,7 @@ public class PseudonymityTest {
         xmlParser = Mockito.mock(XmlParser.class);
         when(fhirContext.newXmlParser()).thenReturn(xmlParser);
         when(privacyProperties.getPseudonymitySecret()).thenReturn("testSecret123");
+        when(privacyProperties.getPseudonomityChunksSize()).thenReturn(5);
     }
 
     private Parameters mockErrorParameters() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -93,6 +93,7 @@ cors:
 privacy:
   minHits: 0
   pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
+  pseudonomityChunksSize: 5
 
 zars:
   enabled: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -92,6 +92,7 @@ cors:
 
 privacy:
   minHits: 0
+  pseudonymitySecret: AVmnrinfsVDRigh4QGrsDFbs43a
 
 zars:
   enabled: false


### PR DESCRIPTION
NUM - 2157 generate fake 3rd level pseudonym when id does not start with codex_ or send back 200 as response but with error in it
- send request to Greiswald in chunks (I guess they restricted the number of original params per request)
- some extra logs