### PR TITLE
NUM-2282 workaround to be able to test file scan when create attachment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <java.version>17</java.version>
     <commons-csv.version>1.10.0</commons-csv.version>
     <jacoco.version>0.8.10</jacoco.version>
-    <dependency-check.version>8.4.0</dependency-check.version>
+    <dependency-check.version>8.4.2</dependency-check.version>
     <failsafe.version>3.1.2</failsafe.version>
     <surefire.version>3.1.2</surefire.version>
     <ehcache.version>3.10.8</ehcache.version>
@@ -390,6 +390,7 @@
           <formats>HTML,XML</formats>
           <skip>${skip.dependency.check}</skip>
           <ossindexAnalyzerEnabled>${ossindexAnalyzerEnabled}</ossindexAnalyzerEnabled>
+          <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/de/vitagroup/num/attachment/domain/dto/AttachmentDto.java
+++ b/src/main/java/de/vitagroup/num/attachment/domain/dto/AttachmentDto.java
@@ -31,4 +31,6 @@ public class AttachmentDto {
     private OffsetDateTime uploadDate;
 
     private String authorId;
+
+    private Long projectId;
 }

--- a/src/main/java/de/vitagroup/num/attachment/domain/repository/AttachmentRepositoryImpl.java
+++ b/src/main/java/de/vitagroup/num/attachment/domain/repository/AttachmentRepositoryImpl.java
@@ -34,6 +34,7 @@ public class AttachmentRepositoryImpl implements AttachmentRepository {
                 .uploadDate(OffsetDateTime.now())
                 .type(model.getType())
                 .content(model.getContent())
+                .projectId(model.getProjectId())
                 .build();
         entity = attachmentRepositoryJpa.save(entity);
         log.info("New attachment with id {} and name {} saved by {} ", entity.getId(), entity.getName(), entity.getAuthorId());

--- a/src/main/java/de/vitagroup/num/attachment/service/AttachmentService.java
+++ b/src/main/java/de/vitagroup/num/attachment/service/AttachmentService.java
@@ -52,7 +52,7 @@ public class AttachmentService {
                         String.format(ExceptionsTemplate.ATTACHMENT_NOT_FOUND, id)));
     }
 
-    public void saveAttachment(MultipartFile file, String description, String loggedInUserId) throws IOException {
+    public void saveAttachment(MultipartFile file, String description, String loggedInUserId, Long projectId) throws IOException {
 
         validate(file);
         AttachmentDto model = AttachmentDto.builder()
@@ -61,6 +61,7 @@ public class AttachmentService {
                 .authorId(loggedInUserId)
                 .type(file.getContentType())
                 .content(file.getBytes())
+                .projectId(projectId)
                 .build();
         attachmentRepository.saveAttachment(model);
     }

--- a/src/main/java/de/vitagroup/num/web/controller/NumAttachmentController.java
+++ b/src/main/java/de/vitagroup/num/web/controller/NumAttachmentController.java
@@ -38,10 +38,10 @@ public class NumAttachmentController extends CustomizedExceptionHandler {
     @AuditLog(description = "Create a new attachment")
     @PreAuthorize(Role.SUPER_ADMIN)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> createAttachment(@AuthenticationPrincipal @NotNull Jwt principal,
+    public ResponseEntity<String> createAttachment(@AuthenticationPrincipal @NotNull Jwt principal, @RequestParam Long projectId,
                                                    @RequestParam(required = false) String description,
                                                    @NotNull @RequestPart("file") MultipartFile file) throws IOException {
-        attachmentService.saveAttachment(file, description, principal.getSubject());
+        attachmentService.saveAttachment(file, description, principal.getSubject(), projectId);
         return ResponseEntity.ok("ok");
     }
 

--- a/src/test/java/de/vitagroup/num/attachment/service/AttachmentServiceTest.java
+++ b/src/test/java/de/vitagroup/num/attachment/service/AttachmentServiceTest.java
@@ -79,7 +79,7 @@ public class AttachmentServiceTest {
     public void saveAttachmentTest() throws IOException {
         ReflectionTestUtils.setField(attachmentService, "pdfFileSize", 10485760);
         MultipartFile mockFile = new MockMultipartFile("testFile", "testFile.pdf", "application/pdf", "%PDF-1.5content".getBytes());
-        attachmentService.saveAttachment(mockFile, null, "author-id");
+        attachmentService.saveAttachment(mockFile, null, "author-id", 1L);
         Mockito.verify(attachmentRepository, Mockito.times(1)).saveAttachment(Mockito.any(AttachmentDto.class));
     }
 
@@ -88,7 +88,7 @@ public class AttachmentServiceTest {
         ReflectionTestUtils.setField(attachmentService, "pdfFileSize", 10485760);
         MultipartFile mockFile = new MockMultipartFile("testFile", "testFile.pdf", "application/pdf", "".getBytes());
         try {
-            attachmentService.saveAttachment(mockFile, null, "author-id");
+            attachmentService.saveAttachment(mockFile, null, "author-id",1L);
         }catch (BadRequestException fe) {
             Assert.assertEquals(INVALID_FILE_MISSING_CONTENT, fe.getMessage());
         }
@@ -99,7 +99,7 @@ public class AttachmentServiceTest {
         ReflectionTestUtils.setField(attachmentService, "pdfFileSize", 10485760);
         MultipartFile mockFile = new MockMultipartFile("testFile", "testFile", "application/pdf", "%PDF-1.5 content".getBytes());
         try {
-            attachmentService.saveAttachment(mockFile, null, "author-id");
+            attachmentService.saveAttachment(mockFile, null, "author-id", 1L);
         }catch (BadRequestException fe) {
             Assert.assertEquals(DOCUMENT_TYPE_MISMATCH, fe.getMessage());
         }
@@ -110,7 +110,7 @@ public class AttachmentServiceTest {
         ReflectionTestUtils.setField(attachmentService, "pdfFileSize", 1);
         MultipartFile mockFile = new MockMultipartFile("testFile", "testFile.pdf", "application/pdf", "%PDF-1.5".getBytes());
         try {
-            attachmentService.saveAttachment(mockFile, null, "author-id");
+            attachmentService.saveAttachment(mockFile, null, "author-id", 1L);
         }catch (BadRequestException fe) {
             Assert.assertEquals(String.format(PDF_FILE_SIZE_EXCEEDED, 0, 0), fe.getMessage());
         }


### PR DESCRIPTION
this is just a workaround till NUM-2292 is finished in order to be able to upload attachments(because attachment requires a field projectId to be filled) and scan them + the fix for build failing due to " Failed to execute goal org.owasp:dependency-check-maven:8.4.0:check (default-cli) on project num-portal: One or more exceptions occurred during dependency-check analysis: One or more exceptions occurred during analysis:  InitializationException: Failed to initialize the RetireJS repo "