### PR TITLE
Fix problems with loading resources in JARs

### DIFF
--- a/src/main/java/org/highmed/numportal/service/ehrbase/ResponseFilter.java
+++ b/src/main/java/org/highmed/numportal/service/ehrbase/ResponseFilter.java
@@ -7,9 +7,10 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.io.File;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -27,10 +28,12 @@ public class ResponseFilter {
   @PostConstruct
   public void initialize() {
     try {
-      File pathResource = new ClassPathResource("resultfilters/pathfilters.txt").getFile();
-      pathFilters = new HashSet<>(Files.readAllLines(pathResource.toPath()));
-      File regexpResource = new ClassPathResource("resultfilters/regexpfilters.txt").getFile();
-      regexpFilters = Files.readAllLines(regexpResource.toPath()).stream().map(Pattern::compile).collect(
+      BufferedReader pathResource = new BufferedReader(new InputStreamReader(
+              new ClassPathResource("resultfilters/pathfilters.txt").getInputStream(), StandardCharsets.UTF_8));
+      pathFilters = new HashSet<>(pathResource.lines().toList());
+      BufferedReader regexpResource = new BufferedReader(new InputStreamReader(
+              new ClassPathResource("resultfilters/regexpfilters.txt").getInputStream(), StandardCharsets.UTF_8));
+      regexpFilters = regexpResource.lines().map(Pattern::compile).collect(
               Collectors.toList());
     } catch (IOException e) {
       log.error("Failed to read project data filters, can't filter results.");
@@ -39,7 +42,7 @@ public class ResponseFilter {
 
   public List<QueryResponseData> filterResponse(List<QueryResponseData> queryResponseDataList) {
     if(pathFilters == null){
-      return new ArrayList<>();
+      return queryResponseDataList;
     }
     List<QueryResponseData> resultList = new ArrayList<>();
     for (QueryResponseData queryResponseData : queryResponseDataList) {

--- a/src/main/java/org/highmed/numportal/service/email/ZarsService.java
+++ b/src/main/java/org/highmed/numportal/service/email/ZarsService.java
@@ -1,13 +1,13 @@
 package org.highmed.numportal.service.email;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.highmed.numportal.domain.dto.ZarsInfoDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.StringUtils;
+import org.highmed.numportal.domain.dto.ZarsInfoDto;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.MessageSource;
 import org.springframework.core.io.ClassPathResource;
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -40,8 +39,7 @@ public class ZarsService {
   @PostConstruct
   public void initialize() {
     try {
-      var resource = new ClassPathResource("ZARSHeaders.json").getFile();
-      var json = new String(Files.readAllBytes(resource.toPath()));
+      var json = new String(new ClassPathResource("ZARSHeaders.json").getInputStream().readAllBytes());
       zarsHeaders = objectMapper.readValue(json, String[].class);
     } catch (IOException e) {
       log.error("Failed to read ZARS headers file, can't send updates to ZARS!");


### PR DESCRIPTION
ClassPathResource.getFile() does not work when the application is deployed as a JAR file, which leads to no result tables being shown, eg. on the search page.