### PR TITLE
Fix NullPointerException in AtnaService

### DIFF
--- a/src/main/java/org/highmed/numportal/service/ProjectService.java
+++ b/src/main/java/org/highmed/numportal/service/ProjectService.java
@@ -1240,6 +1240,8 @@ public class ProjectService {
                 .firstHypotheses(undef)
                 .secondHypotheses(undef)
                 .description("Temporary project for manager data retrieval")
+                .coordinator(UserDetails.builder().userId(undef).organization(Organization.builder().id(0L).build()).build())
+                .status(ProjectStatus.DENIED)
                 .build();
     }
 


### PR DESCRIPTION
ProjectService.executeManagerProject() is used when the the user is logged in as manager. Because a manager does not need to have a project, createManagerProject() is called to create a "fake" project. This project is later used in atnaService.logDataExport(). The fake project doesn't have the necessary fields, so a NPE occurs there. This commit adds these fields.