### PR TITLE
Use uppercase for AQL type 'EHR'

### DIFF
--- a/src/main/java/org/highmed/numportal/service/ehrbase/EhrBaseService.java
+++ b/src/main/java/org/highmed/numportal/service/ehrbase/EhrBaseService.java
@@ -42,7 +42,7 @@ import static org.highmed.numportal.domain.templates.ExceptionsTemplate.*;
 public class EhrBaseService {
 
   private static final Aql ALL_PATIENTS_IDS =
-          Aql.builder().query("select e/ehr_id/value from ehr e").build();
+          Aql.builder().query("SELECT e/ehr_id/value FROM EHR e").build();
 
   private static final String COMPOSITION_KEY = "_type";
   private static final String NAME = "name";


### PR DESCRIPTION
Use uppercase for AQL type 'EHR', otherwise the following error occurs with EHRbase 2.4:
```
Generated query for retrieveEligiblePatientIds SELECT e/ehr_id/value FROM ehr e
EhrBase - Malformed query exception: Wrong Status code. Expected: [200, 201, 204]. Got: 400. Error message: {"error":"Bad 
Request","message":"Type ehr is not supported in FROM, only: EHR, CONTENT_ITEM, ENTRY, CARE_ENTRY, EVENT, 
ITEM_STRUCTURE, ITEM, COMPOSITION, FOLDER, EHR_STATUS, EVENT_CONTEXT, SECTION, GENERIC_ENTRY, ADMIN_ENTRY, 
OBSERVATION, INSTRUCTION, ACTION, EVALUATION, ACTIVITY, HISTORY, POINT_EVENT, INTERVAL_EVENT, FEEDER_AUDIT, 
ITEM_LIST, ITEM_SINGLE, ITEM_TABLE, ITEM_TREE, CLUSTER, ELEMENT"}

org.ehrbase.openehr.sdk.util.exception.WrongStatusCodeException: Wrong Status code. Expected: [200, 201, 204]. Got: 400. Error 
message: {"error":"Bad Request","message":"Type ehr is not supported in FROM, only: EHR, CONTENT_ITEM, ENTRY, CARE_ENTRY, 
EVENT, ITEM_STRUCTURE, ITEM, COMPOSITION, FOLDER, EHR_STATUS, EVENT_CONTEXT, SECTION, GENERIC_ENTRY, 
ADMIN_ENTRY, OBSERVATION, INSTRUCTION, ACTION, EVALUATION, ACTIVITY, HISTORY, POINT_EVENT, INTERVAL_EVENT, 
FEEDER_AUDIT, ITEM_LIST, ITEM_SINGLE, ITEM_TABLE, ITEM_TREE, CLUSTER, ELEMENT"}
```