### PR TITLE
feat: option to set default limit for all queries

### DIFF
--- a/src/main/java/org/highmed/numportal/properties/EhrBaseProperties.java
+++ b/src/main/java/org/highmed/numportal/properties/EhrBaseProperties.java
@@ -20,4 +20,6 @@ public class EhrBaseProperties {
   private String adminPassword;
 
   private String idPath = "ehr_status/subject/external_ref/id/value";
+
+  private Long limit;
 }

--- a/src/main/java/org/highmed/numportal/service/ehrbase/EhrBaseService.java
+++ b/src/main/java/org/highmed/numportal/service/ehrbase/EhrBaseService.java
@@ -174,6 +174,11 @@ public class EhrBaseService {
   public List<QueryResponseData> executeRawQuery(AqlQuery aqlDto, Long projectId) {
 
     addSelectSecondlevelPseudonyms(aqlDto);
+
+    if (aqlDto.getLimit() == null && ehrBaseProperties.getLimit() != null) {
+      aqlDto.setLimit(ehrBaseProperties.getLimit());
+    }
+
     String query = AqlRenderer.render(aqlDto);
 
     try {
@@ -200,6 +205,10 @@ public class EhrBaseService {
   }
 
   public QueryResponseData executePlainQuery(String queryString) {
+
+    if (!queryString.toLowerCase().contains("limit ") && ehrBaseProperties.getLimit() != null) {
+      queryString += " LIMIT " + ehrBaseProperties.getLimit();
+    }
 
     NativeQuery<Record> query = Query.buildNativeQuery(queryString);
 


### PR DESCRIPTION
Some openEHR platforms enforce a limit by default. So a lot of the queries by the tool won't work properly. 
Also for dev purposes it might make sense to limit the output to a couple results, so the server won't get overwhelmed by queries.

Therefore I propose the addition of a `limit` parameter. This will add the given limit to all queries, unless they already contain a limit clause.

It can be set in the ehrbase section of the yml as follows

```
...
ehrbase:
  limit: 100000000
...
```

the other alternative would be via an env variable:
```
EHRBASE_LIMIT=100000000
```